### PR TITLE
Fix issue #21 - memory leak

### DIFF
--- a/src/main/java/com/lambdaworks/redis/pubsub/PubSubCommandHandler.java
+++ b/src/main/java/com/lambdaworks/redis/pubsub/PubSubCommandHandler.java
@@ -55,6 +55,8 @@ public class PubSubCommandHandler<K, V> extends CommandHandler<K, V> {
             ctx.fireChannelRead(output);
             output = new PubSubOutput<K, V>(codec);
         }
+        
+        buffer.discardReadBytes();
     }
 
 }

--- a/src/main/java/com/lambdaworks/redis/pubsub/PubSubCommandHandler.java
+++ b/src/main/java/com/lambdaworks/redis/pubsub/PubSubCommandHandler.java
@@ -54,9 +54,8 @@ public class PubSubCommandHandler<K, V> extends CommandHandler<K, V> {
         while (rsm.decode(buffer, output)) {
             ctx.fireChannelRead(output);
             output = new PubSubOutput<K, V>(codec);
+            buffer.discardReadBytes();
         }
-        
-        buffer.discardReadBytes();
     }
 
 }


### PR DESCRIPTION
Read buffer bytes need to be discarded by decode().
See issue #21 for more information.