### PR TITLE
Fix channel loss on reconnect

### DIFF
--- a/src/main/java/com/lambdaworks/redis/pubsub/RedisPubSubConnectionImpl.java
+++ b/src/main/java/com/lambdaworks/redis/pubsub/RedisPubSubConnectionImpl.java
@@ -97,12 +97,10 @@ public class RedisPubSubConnectionImpl<K, V> extends RedisAsyncConnectionImpl<K,
 
         if (!channels.isEmpty()) {
             subscribe(toArray(channels));
-            channels.clear();
         }
 
         if (!patterns.isEmpty()) {
             psubscribe(toArray(patterns));
-            patterns.clear();
         }
     }
 


### PR DESCRIPTION
The scenario requires two or more close-by disconnections
1. Connect to Redis
2. Subscribe successfully to a channel
3. Forcibly kill the connection (by taking down Redis for example)
4. Let lettuce reconnect successfully
5. Forcibly kill the connection again right before activate() successfully subscribes
6. Let lettuce reconnect successfully
7. RedisPubSubConnectionImpl.channels is empty and the channel will stay unsubscribed

There doesn't seem to be a reason to clear out channels and patterns.
It is only used for persistence over different connections.
There is no downside to having a channel in that set even if the subscription was not successful.