### PR TITLE
Pool return no longer nulls connection

### DIFF
--- a/src/main/java/com/lambdaworks/redis/PooledConnectionInvocationHandler.java
+++ b/src/main/java/com/lambdaworks/redis/PooledConnectionInvocationHandler.java
@@ -39,7 +39,6 @@ class PooledConnectionInvocationHandler<T> extends AbstractInvocationHandler {
 
         if (method.getName().equals("close")) {
             pool.freeConnection((T) proxy);
-            connection = null;
             return null;
         }
 


### PR DESCRIPTION
The borrowed object would be returned to the pool on pool.freeResource() properly
If close() was called, it would return the resource to the pool,
then null the connection.