### PR TITLE
Update pom to suppress javadoc errors on Java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,29 @@
         </dependency>
 
     </dependencies>
+    <profiles>
+        <profile>
+            <id>doclint-java8-disable</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <!-- java 8 doclint html verification is excluded to suppress strict HTML 4.0 compliance errors 
+                         like "error: self-closing element not allowed <p/>"   -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <!--<additionalparam>-Xdoclint:all -Xdoclint:-html</additionalparam>-->
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile> 
+    </profiles>
 
     <build>
         <plugins>


### PR DESCRIPTION
Java8 will fail when building due to stricter javadoc requirements. This will disable that linting. Errors look like this:
```
[ERROR] src/main/java/com/lambdaworks/redis/BaseRedisAsyncConnection.java:47: warning: no description for @param
```

Alternative is to always use `-Dmaven.javadoc.skip=true` on the command line


Slightly modified from pom.xml at
https://github.com/dropwizard/metrics
and
https://jdpgrailsdev.github.io/blog/2014/04/03/maven_java8_javadoc.html
for the none