### PR TITLE
Add some cluster commands to non-cluster client: Readonly, and expose cluster query commands

### DIFF
--- a/src/main/java/com/lambdaworks/redis/BaseRedisAsyncConnection.java
+++ b/src/main/java/com/lambdaworks/redis/BaseRedisAsyncConnection.java
@@ -79,20 +79,7 @@ public interface BaseRedisAsyncConnection<K, V> extends Closeable {
      */
     RedisFuture<String> ping();
 
-    RedisFuture<String> clusterNodes();
-
-    RedisFuture<String> clusterInfo();
-
-    RedisFuture<List<K>> clusterGetKeysInSlot(int slot, int count);
-
-    /**
-     * Get array of Cluster slot to node mappings.
-     *
-     * @return List&lt;Object&gt; array-reply nested list of slot ranges with IP/Port mappings.
-     */
-    RedisFuture<List<Object>> clusterSlots();
-
-    RedisFuture<String> readOnly();
+    String readOnly();
 
     /**
      * Close the connection.

--- a/src/main/java/com/lambdaworks/redis/BaseRedisAsyncConnection.java
+++ b/src/main/java/com/lambdaworks/redis/BaseRedisAsyncConnection.java
@@ -79,6 +79,21 @@ public interface BaseRedisAsyncConnection<K, V> extends Closeable {
      */
     RedisFuture<String> ping();
 
+    RedisFuture<String> clusterNodes();
+
+    RedisFuture<String> clusterInfo();
+
+    RedisFuture<List<K>> clusterGetKeysInSlot(int slot, int count);
+
+    /**
+     * Get array of Cluster slot to node mappings.
+     *
+     * @return List&lt;Object&gt; array-reply nested list of slot ranges with IP/Port mappings.
+     */
+    RedisFuture<List<Object>> clusterSlots();
+
+    RedisFuture<String> readOnly();
+
     /**
      * Close the connection.
      * 

--- a/src/main/java/com/lambdaworks/redis/BaseRedisAsyncConnection.java
+++ b/src/main/java/com/lambdaworks/redis/BaseRedisAsyncConnection.java
@@ -81,6 +81,8 @@ public interface BaseRedisAsyncConnection<K, V> extends Closeable {
 
     String readOnly();
 
+    String readWrite();
+
     /**
      * Close the connection.
      * 

--- a/src/main/java/com/lambdaworks/redis/BaseRedisConnection.java
+++ b/src/main/java/com/lambdaworks/redis/BaseRedisConnection.java
@@ -77,19 +77,6 @@ public interface BaseRedisConnection<K, V> extends Closeable {
      */
     String ping();
 
-    String clusterNodes();
-
-    Map<K, V> clusterInfo();
-
-    List<K> clusterGetKeysInSlot(int slot, int count);
-
-    /**
-     * Get array of Cluster slot to node mappings.
-     *
-     * @return List&lt;Object&gt; array-reply nested list of slot ranges with IP/Port mappings.
-     */
-    List<Object> clusterSlots();
-
     String readOnly();
 
     /**

--- a/src/main/java/com/lambdaworks/redis/BaseRedisConnection.java
+++ b/src/main/java/com/lambdaworks/redis/BaseRedisConnection.java
@@ -1,7 +1,6 @@
 package com.lambdaworks.redis;
 
 import java.io.Closeable;
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -77,6 +76,21 @@ public interface BaseRedisConnection<K, V> extends Closeable {
      * @return String simple-string-reply
      */
     String ping();
+
+    String clusterNodes();
+
+    Map<K, V> clusterInfo();
+
+    List<K> clusterGetKeysInSlot(int slot, int count);
+
+    /**
+     * Get array of Cluster slot to node mappings.
+     *
+     * @return List&lt;Object&gt; array-reply nested list of slot ranges with IP/Port mappings.
+     */
+    List<Object> clusterSlots();
+
+    String readOnly();
 
     /**
      * Close the connection.

--- a/src/main/java/com/lambdaworks/redis/BaseRedisConnection.java
+++ b/src/main/java/com/lambdaworks/redis/BaseRedisConnection.java
@@ -79,6 +79,8 @@ public interface BaseRedisConnection<K, V> extends Closeable {
 
     String readOnly();
 
+    String readWrite();
+
     /**
      * Close the connection.
      * 

--- a/src/main/java/com/lambdaworks/redis/RedisAsyncConnection.java
+++ b/src/main/java/com/lambdaworks/redis/RedisAsyncConnection.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
 public interface RedisAsyncConnection<K, V> extends RedisHashesAsyncConnection<K, V>, RedisKeysAsyncConnection<K, V>,
         RedisStringsAsyncConnection<K, V>, RedisListsAsyncConnection<K, V>, RedisSetsAsyncConnection<K, V>,
         RedisSortedSetsAsyncConnection<K, V>, RedisScriptingAsyncConnection<K, V>, RedisServerAsyncConnection<K, V>,
-        RedisHLLAsyncConnection<K, V>, BaseRedisAsyncConnection<K, V> {
+        RedisHLLAsyncConnection<K, V>, BaseRedisAsyncConnection<K, V> , RedisClusterAsyncConnection<K, V>{
 
     /**
      * Set the default timeout for operations.

--- a/src/main/java/com/lambdaworks/redis/RedisAsyncConnectionImpl.java
+++ b/src/main/java/com/lambdaworks/redis/RedisAsyncConnectionImpl.java
@@ -605,6 +605,10 @@ public class RedisAsyncConnectionImpl<K, V> extends RedisChannelHandler<K, V> im
     public RedisFuture<String> ping() {
         return dispatch(commandBuilder.ping());
     }
+    @Override
+    public RedisFuture<String> readOnly() {
+        return dispatch(commandBuilder.readOnly());
+    }
 
     @Override
     public RedisFuture<Long> pttl(K key) {

--- a/src/main/java/com/lambdaworks/redis/RedisAsyncConnectionImpl.java
+++ b/src/main/java/com/lambdaworks/redis/RedisAsyncConnectionImpl.java
@@ -605,9 +605,11 @@ public class RedisAsyncConnectionImpl<K, V> extends RedisChannelHandler<K, V> im
     public RedisFuture<String> ping() {
         return dispatch(commandBuilder.ping());
     }
+
     @Override
-    public RedisFuture<String> readOnly() {
-        return dispatch(commandBuilder.readOnly());
+    public String readOnly() {
+        RedisCommand<K, V, String> cmd = dispatch(commandBuilder.readOnly());
+        return LettuceFutures.await(cmd, timeout, unit);
     }
 
     @Override

--- a/src/main/java/com/lambdaworks/redis/RedisAsyncConnectionImpl.java
+++ b/src/main/java/com/lambdaworks/redis/RedisAsyncConnectionImpl.java
@@ -613,6 +613,12 @@ public class RedisAsyncConnectionImpl<K, V> extends RedisChannelHandler<K, V> im
     }
 
     @Override
+    public String readWrite() {
+        RedisCommand<K, V, String> cmd = dispatch(commandBuilder.readWrite());
+        return LettuceFutures.await(cmd, timeout, unit);
+    }
+
+    @Override
     public RedisFuture<Long> pttl(K key) {
         return dispatch(commandBuilder.pttl(key));
     }

--- a/src/main/java/com/lambdaworks/redis/RedisClusterConnection.java
+++ b/src/main/java/com/lambdaworks/redis/RedisClusterConnection.java
@@ -1,7 +1,6 @@
 package com.lambdaworks.redis;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Complete synchronous cluster Redis API with 400+ Methods..
@@ -23,7 +22,7 @@ public interface RedisClusterConnection<K, V> extends RedisHashesConnection<K, V
 
     String clusterDelSlots(int... slots);
 
-    Map<K, V> clusterInfo();
+    String clusterInfo();
 
     String clusterNodes();
 

--- a/src/main/java/com/lambdaworks/redis/RedisCommandBuilder.java
+++ b/src/main/java/com/lambdaworks/redis/RedisCommandBuilder.java
@@ -524,6 +524,9 @@ class RedisCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
     public Command<K, V, String> ping() {
         return createCommand(PING, new StatusOutput<K, V>(codec));
     }
+    public Command<K, V, String> readOnly() {
+        return createCommand(READONLY, new StatusOutput<K, V>(codec));
+    }
 
     public Command<K, V, Long> pttl(K key) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key);

--- a/src/main/java/com/lambdaworks/redis/RedisCommandBuilder.java
+++ b/src/main/java/com/lambdaworks/redis/RedisCommandBuilder.java
@@ -528,6 +528,11 @@ class RedisCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
         return createCommand(READONLY, new StatusOutput<K, V>(codec));
     }
 
+    public Command<K, V, String> readWrite() {
+        return createCommand(READWRITE, new StatusOutput<K, V>(codec));
+    }
+
+
     public Command<K, V, Long> pttl(K key) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key);
         return createCommand(PTTL, new IntegerOutput<K, V>(codec), args);

--- a/src/main/java/com/lambdaworks/redis/RedisConnection.java
+++ b/src/main/java/com/lambdaworks/redis/RedisConnection.java
@@ -13,7 +13,8 @@ import java.util.concurrent.TimeUnit;
  */
 public interface RedisConnection<K, V> extends RedisHashesConnection<K, V>, RedisKeysConnection<K, V>,
         RedisStringsConnection<K, V>, RedisListsConnection<K, V>, RedisSetsConnection<K, V>, RedisSortedSetsConnection<K, V>,
-        RedisScriptingConnection<K, V>, RedisServerConnection<K, V>, RedisHLLConnection<K, V>, BaseRedisConnection<K, V> {
+        RedisScriptingConnection<K, V>, RedisServerConnection<K, V>, RedisHLLConnection<K, V>, BaseRedisConnection<K, V>,
+        RedisClusterConnection<K, V>{
 
     /**
      * Set the default timeout for operations.

--- a/src/main/java/com/lambdaworks/redis/protocol/CommandType.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/CommandType.java
@@ -10,7 +10,7 @@ package com.lambdaworks.redis.protocol;
 public enum CommandType {
     // Connection
 
-    AUTH, ECHO, PING, QUIT, SELECT,
+    AUTH, ECHO, PING, QUIT, READONLY, SELECT,
 
     // Server
 

--- a/src/main/java/com/lambdaworks/redis/protocol/CommandType.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/CommandType.java
@@ -10,7 +10,7 @@ package com.lambdaworks.redis.protocol;
 public enum CommandType {
     // Connection
 
-    AUTH, ECHO, PING, QUIT, READONLY, SELECT,
+    AUTH, ECHO, PING, QUIT, READONLY, READWRITE, SELECT,
 
     // Server
 

--- a/src/test/java/com/lambdaworks/redis/SyncAsyncApiConvergenceTest.java
+++ b/src/test/java/com/lambdaworks/redis/SyncAsyncApiConvergenceTest.java
@@ -72,7 +72,8 @@ public class SyncAsyncApiConvergenceTest {
             }
         }
 
-        assertThat(returnType).isEqualTo(this.method.getReturnType());
+        assertThat(returnType).describedAs(this.method.toString())
+            .isEqualTo(this.method.getReturnType());
 
     }
 }


### PR DESCRIPTION
This is to surface some redis cluster commands on the normal non-cluster connection interface..

We need to connect via a non-cluster client to perform read operations on the slave. The readonly() command allows the slave to answer if it contains the slot for the key. The other additions are cluster query commands that can help a client determine more information about the node it's connected to.

I just added the commands directly to the BaseRedis*Connection interfaces. An alternative could be to create a new RedisClusterQueryConnection interface that has just the readonly command and query cluster* commands


Added readonly command to allow a non-cluster aware slave connection perform read
operations.
Add clusterNodes command to BaseConnection. If the node is a cluster, allows simple
client to obtain cluster information. Useful with above readonly command to direct
traffic to slave nodes explicitly
Add other cluster read status commands