### PR TITLE
Removing exclusion for Guavas primitives in shading, used by SlotHash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,6 @@
                                         <exclude>com/google/common/hash/**</exclude>
                                         <exclude>com/google/common/html/**</exclude>
                                         <exclude>com/google/common/math/**</exclude>
-                                        <exclude>com/google/common/primitives/**</exclude>
                                         <exclude>com/google/common/xml/**</exclude>
                                     </excludes>
                                 </filter>


### PR DESCRIPTION
Small one: I build the shaded jar and ran into ClassNotFound for com.google.common.primitives.Chars when loading SlotHash

It was being excluded in the shaded jar. 
