### PR TITLE
Fix synchronized issue

### DIFF
--- a/src/main/java/com/lambdaworks/redis/codec/Utf8StringCodec.java
+++ b/src/main/java/com/lambdaworks/redis/codec/Utf8StringCodec.java
@@ -50,8 +50,7 @@ public class Utf8StringCodec extends RedisCodec<String, String> {
         return encode(value);
     }
 
-    private String decode(ByteBuffer bytes) {
-        synchronized (chars) {
+    private synchronized String decode(ByteBuffer bytes) {
             chars.clear();
             bytes.mark();
 
@@ -62,7 +61,6 @@ public class Utf8StringCodec extends RedisCodec<String, String> {
             }
 
             return chars.flip().toString();
-        }
     }
 
     private byte[] encode(String string) {


### PR DESCRIPTION
This was what I was attempting to test when I found issue #42. There is a potential threading issue in the decoder.
It was syncing on chars, which can be reassigned in the called method.
Instead just synchronizing on the Codec itself. Left reformatting till later.