### PR TITLE
Multi fix: Futures aren't throwing on key violation

### DIFF
--- a/src/main/java/com/lambdaworks/redis/protocol/Command.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/Command.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import com.google.common.util.concurrent.AbstractFuture;
+import com.lambdaworks.redis.RedisCommandExecutionException;
 import com.lambdaworks.redis.RedisCommandInterruptedException;
 import io.netty.buffer.ByteBuf;
 
@@ -108,6 +109,9 @@ public class Command<K, V, T> extends AbstractFuture<T> implements RedisCommand<
             latch.await();
             if (exception != null) {
                 throw new ExecutionException(exception);
+            }
+            if (getError() != null) {
+                throw new ExecutionException(new RedisCommandExecutionException(getError()));
             }
 
             return output.get();


### PR DESCRIPTION
Commands issued in a multi block returned futures who would not throw exceptions for key violations. I wrote a small test case following redis.io's transaction page
```
MULTI
+OK
SET a 3
abc
+QUEUED
LPOP a
+QUEUED
EXEC
*2
+OK
-ERR Operation against a key holding the wrong kind of value
```
The future for the LPOP should throw an exception on get(), but it was returning null.

For now, this patch looks at the error portion of the output to ensure there was no error. We should do better, but that will require a bit more work. 

The work will be in RedisStateMachine(RSM). Now, on an error in a multi block, the command is the exec(), and the output is the target. The RSM correctly delivers the error to the output handler, but it really should have the exec command know of the multi command to deliver the both the result or the error. As of now, we'll have to do a bit more to get that.

I have a bit more coming, but this is in a deliverable state