### PR TITLE
Docs: Change RELEASE-NOTES file extension to md for Markdown

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,4 @@
-              lettuce 3.3.Final RELEASE NOTES
+# lettuce 3.3.Final RELEASE NOTES
 
 lettuce 3.3 introduces a variety of changes: It features changes to cluster support,
 new Geo commands for the upcoming Redis 3.2 release and allows batching, an extension

--- a/src/assembly/bin.xml
+++ b/src/assembly/bin.xml
@@ -53,7 +53,7 @@
             <includes>
                 <include>LICENSE</include>
                 <include>README.md</include>
-                <include>RELEASE-NOTES.txt</include>
+                <include>RELEASE-NOTES.md</include>
             </includes>
         </fileSet>
     </fileSets>


### PR DESCRIPTION
By changing the file extension the rendering of the document on GitHub looks much better.