### PR TITLE
Use much faster JDK utility for converting an int to a byte sequence.

### DIFF
--- a/src/main/java/com/lambdaworks/redis/protocol/CommandArgs.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/CommandArgs.java
@@ -220,21 +220,15 @@ public class CommandArgs<K, V> {
         return this;
     }
 
-    private void write(long value) {
+    private void write(int value) {
         if (value < 10) {
             buffer.put((byte) ('0' + value));
             return;
         }
 
-        StringBuilder sb = new StringBuilder(8);
-        while (value > 0) {
-            long digit = value % 10;
-            sb.append((char) ('0' + digit));
-            value /= 10;
-        }
-
-        for (int i = sb.length() - 1; i >= 0; i--) {
-            buffer.put((byte) sb.charAt(i));
+        String asString = Integer.toString(value);
+        for (int i = 0; i < asString.length(); i++) {
+            buffer.put((byte) asString.charAt(i));
         }
     }
 


### PR DESCRIPTION
At the moment Lettuce uses a private helper method accepting a long parameter to write the length of a String or byte array to redis.
First off, this length will be always "int",
secondly, the method uses a hand written StringBuilder and number % 10 algorithm to translate the long into a string.
It will produce a String 4321 for a length of 1234. This string will be reversed and the char values appended to the buffer.

The JDK however comes with the handy util Integer.toString(intValue) which will produce a correctly ordered String. This method is much faster and also benefits from improvements done to the JDK
(this was actually done quite recently: http://mail.openjdk.java.net/pipermail/core-libs-dev/2015-November/036765.html)

In summary this improves CPU and memory usage of this method.