### PR TITLE
Bug fix: fix NOAUTH error...

### DIFF
--- a/src/main/java/com/lambdaworks/redis/cluster/ClusterTopologyRefresh.java
+++ b/src/main/java/com/lambdaworks/redis/cluster/ClusterTopologyRefresh.java
@@ -221,7 +221,7 @@ class ClusterTopologyRefresh {
                 RedisAsyncConnectionImpl<String, String> connection = client.connectAsyncImpl(redisURI.getResolvedAddress());
                 if (redisURI.getPassword() != null) {
                     String password = new String(redisURI.getPassword());
-                    if (!"".equals(password)) {
+                    if (!"".equals(password.trim())) {
                         connection.auth(password);
                     }
                 }

--- a/src/main/java/com/lambdaworks/redis/cluster/ClusterTopologyRefresh.java
+++ b/src/main/java/com/lambdaworks/redis/cluster/ClusterTopologyRefresh.java
@@ -219,6 +219,10 @@ class ClusterTopologyRefresh {
 
             try {
                 RedisAsyncConnectionImpl<String, String> connection = client.connectAsyncImpl(redisURI.getResolvedAddress());
+                char[] password = redisURI.getPassword();
+                if (password != null) {
+                    connection.auth(new String(password));
+                }
                 connections.put(redisURI, connection);
             } catch (RuntimeException e) {
                 logger.warn("Cannot connect to " + redisURI, e);

--- a/src/main/java/com/lambdaworks/redis/cluster/ClusterTopologyRefresh.java
+++ b/src/main/java/com/lambdaworks/redis/cluster/ClusterTopologyRefresh.java
@@ -219,9 +219,11 @@ class ClusterTopologyRefresh {
 
             try {
                 RedisAsyncConnectionImpl<String, String> connection = client.connectAsyncImpl(redisURI.getResolvedAddress());
-                char[] password = redisURI.getPassword();
-                if (password != null) {
-                    connection.auth(new String(password));
+                if (redisURI.getPassword() != null) {
+                    String password = new String(redisURI.getPassword());
+                    if (!"".equals(password)) {
+                        connection.auth(password);
+                    }
                 }
                 connections.put(redisURI, connection);
             } catch (RuntimeException e) {


### PR DESCRIPTION
Fix NOAUTH error when connecting to a cluster with password protection.

Before loading partition views, call auth() method if a none-empty password is provided after connected to any server of a cluster.