### PR TITLE
mget with Iterable within redis cluster not working

### DIFF
--- a/src/main/java/com/lambdaworks/redis/cluster/RedisAdvancedClusterAsyncCommandsImpl.java
+++ b/src/main/java/com/lambdaworks/redis/cluster/RedisAdvancedClusterAsyncCommandsImpl.java
@@ -90,8 +90,8 @@ public class RedisAdvancedClusterAsyncCommandsImpl<K, V> extends AbstractRedisAs
     }
 
     @Override
-    public RedisFuture<List<V>> mget(K... keys) {
-        Map<Integer, List<K>> partitioned = SlotHash.partition(codec, Arrays.asList(keys));
+    public RedisFuture<List<V>> mget(Iterable<K> keys) {
+        Map<Integer, List<K>> partitioned = SlotHash.partition(codec, keys);
 
         if (partitioned.size() < 2) {
             return super.mget(keys);
@@ -118,6 +118,11 @@ public class RedisAdvancedClusterAsyncCommandsImpl<K, V> extends AbstractRedisAs
 
             return result;
         });
+    }
+
+    @Override
+    public RedisFuture<List<V>> mget(K... keys) {
+        return mget(Arrays.asList(keys));
     }
 
     @Override


### PR DESCRIPTION
If you try to use mget on a redis cluster, two methods are defined, the first with varargs and the other with a Collection of keys. The second one is not override by the RedisAdvancedClusterAsyncCommandsImpl, then if you try to use it you will have an error :  "**ERR CROSSSLOT Keys in request don't hash to the same slot**"