### PR TITLE
Change MethodTranslator's loadfactor to 1.0 for sync APIs performance

### DIFF
--- a/src/main/java/com/lambdaworks/redis/internal/AbstractInvocationHandler.java
+++ b/src/main/java/com/lambdaworks/redis/internal/AbstractInvocationHandler.java
@@ -109,7 +109,7 @@ public abstract class AbstractInvocationHandler implements InvocationHandler {
 
     protected static class MethodTranslator {
 
-        private final Map<Method, Method> map = new HashMap<>();
+        private final Map<Method, Method> map;
 
         public MethodTranslator(Class<?> delegate, Class<?>... methodSources) {
 
@@ -117,6 +117,8 @@ public abstract class AbstractInvocationHandler implements InvocationHandler {
             for (Class<?> sourceClass : methodSources) {
                 methods.addAll(getMethods(sourceClass));
             }
+
+            map = new HashMap<>(methods.size(), 1.0f);
 
             for (Method method : methods) {
 


### PR DESCRIPTION
This is a trivial thing. I updated `MethodTranslator`'s loadfactor to 1.0 for sync APIs performance.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/mp911de/lettuce/blob/master/.github/CONTRIBUTING.md).
- [x] You use the code formatters provided [here](https://github.com/mp911de/lettuce/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->