### PR TITLE
Avoid timeouts for cancelling command

### DIFF
--- a/src/main/java/com/lambdaworks/redis/protocol/AsyncCommand.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/AsyncCommand.java
@@ -101,8 +101,12 @@ public class AsyncCommand<K, V, T> extends CompletableFuture<T> implements Redis
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
-        command.cancel();
-        return super.cancel(mayInterruptIfRunning);
+        try {
+            command.cancel();
+            return super.cancel(mayInterruptIfRunning);
+        } finally {
+            latch.countDown();
+        }
     }
 
     @Override

--- a/src/test/java/com/lambdaworks/redis/commands/AsyncCommandInternalsTest.java
+++ b/src/test/java/com/lambdaworks/redis/commands/AsyncCommandInternalsTest.java
@@ -3,6 +3,7 @@ package com.lambdaworks.redis.commands;
 import static com.lambdaworks.redis.protocol.LettuceCharsets.buffer;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -73,6 +74,12 @@ public class AsyncCommandInternalsTest {
     public void awaitWithExecutionException() throws Exception {
         sut.completeExceptionally(new RedisException("error"));
         LettuceFutures.awaitOrCancel(sut, 1, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = CancellationException.class)
+    public void awaitWithCancelledCommand() throws Exception {
+        sut.cancel();
+        LettuceFutures.awaitOrCancel(sut, 5, TimeUnit.SECONDS);
     }
 
     @Test(expected = RedisException.class)


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/mp911de/lettuce/blob/master/.github/CONTRIBUTING.md).
- [x] You use the code formatters provided [here](https://github.com/mp911de/lettuce/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

When an `AsyncCommand` was cancelled in another thread, `LettuceFutures#awaitOrCancel()` waited for long time and a timeout exception occured. So, I updated `AsyncCommand#cancel()` method using `latch#countDown()`, it'll occured an cancelled exception directly without meaningless waiting.

Previously:
```
Caused by: com.lambdaworks.redis.RedisCommandTimeoutException: Command timed out
    at com.lambdaworks.redis.LettuceFutures.await(LettuceFutures.java:98)
    at com.lambdaworks.redis.LettuceFutures.awaitOrCancel(LettuceFutures.java:77)
    at com.lambdaworks.redis.commands.AsyncCommandInternalsTest.cancelWhileAwaitWithException(AsyncCommandInternalsTest.java:89)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.internal.runners.statements.ExpectException.evaluate(ExpectException.java:19)
    ... 19 more
```