### PR TITLE
The exception was not occured in evalsha when I use MULTI return type

### DIFF
--- a/src/main/java/com/lambdaworks/redis/output/NestedMultiOutput.java
+++ b/src/main/java/com/lambdaworks/redis/output/NestedMultiOutput.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 
-import com.lambdaworks.redis.RedisCommandExecutionException;
 import com.lambdaworks.redis.codec.RedisCodec;
 import com.lambdaworks.redis.internal.LettuceFactories;
 
@@ -36,11 +35,6 @@ public class NestedMultiOutput<K, V> extends CommandOutput<K, V, List<Object>> {
     @Override
     public void set(ByteBuffer bytes) {
         output.add(bytes == null ? null : codec.decodeValue(bytes));
-    }
-
-    @Override
-    public void setError(ByteBuffer error) {
-        output.add(new RedisCommandExecutionException(decodeAscii(error)));
     }
 
     @Override

--- a/src/test/java/com/lambdaworks/redis/commands/ScriptingCommandTest.java
+++ b/src/test/java/com/lambdaworks/redis/commands/ScriptingCommandTest.java
@@ -72,6 +72,14 @@ public class ScriptingCommandTest extends AbstractRedisClientTest {
     }
 
     @Test
+    public void evalshaWithMulti() throws Exception {
+        redis.scriptFlush();
+        String digest = redis.digest("return {1234, 5678}");
+        exception.expectMessage("NOSCRIPT No matching script. Please use EVAL.");
+        redis.evalsha(digest, MULTI);
+    }
+
+    @Test
     public void evalshaWithKeys() throws Exception {
         redis.scriptFlush();
         String digest = redis.scriptLoad("return {KEYS[1], KEYS[2]}");

--- a/src/test/java/com/lambdaworks/redis/protocol/CommandInternalsTest.java
+++ b/src/test/java/com/lambdaworks/redis/protocol/CommandInternalsTest.java
@@ -115,7 +115,7 @@ public class CommandInternalsTest {
     public void nestedMultiError() throws Exception {
         NestedMultiOutput<String, String> output = new NestedMultiOutput<String, String>(codec);
         output.setError(buffer("Oops!"));
-        assertThat(output.get().get(0) instanceof RedisException).isTrue();
+        assertThat(output.getError()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/mp911de/lettuce/blob/master/.github/CONTRIBUTING.md).
- [x] You use the code formatters provided [here](https://github.com/mp911de/lettuce/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

When an exception occured in `evalsha()`, it will be thrown. But, if I use `evalsha()` with `MULTI` return type, the exception didn't occured and it was included in result. This behavior is strange for users.

# Case 1: Normal case.

This case use `evalsha` with `ScriptOutputType.STATUS` return type.

```java
@Test
public void lettuceLuaUnknownSha1TestWithStatus() throws InterruptedException {
    RedisClient lettuce = RedisClient.create("redis://localhost:6379");
    RedisAsyncCommands<String, String> client = lettuce.connect().async();
    RedisFuture<String> results = client.evalsha("unknown-sha1", ScriptOutputType.STATUS, "test1");
    results.whenComplete((res, ex) -> {
        logger.info("results=" + res);
        logger.info("ex=" + ex);
    });
    Thread.sleep(10000);
}
```

Output: normal case. `results` was null, and the exception was delivered into `ex`. 
```
results=null
ex=com.lambdaworks.redis.RedisCommandExecutionException: NOSCRIPT No matching script. Please use EVAL.
```

# Case 2: Strange case

This case use `evalsha` with `ScriptOutputType.MULTI` return type.

Code:
```java
@Test
public void lettuceLuaUnknownSha1WithMulti() throws InterruptedException {
    RedisClient lettuce = RedisClient.create("redis://localhost:6379");
    RedisAsyncCommands<String, String> client = lettuce.connect().async();
    RedisFuture<List<Object>> results = client.evalsha("unknown-sha1", ScriptOutputType.MULTI, "test1");
    results.whenComplete((res, ex) -> {
        logger.info("results=" + res);
        logger.info("ex=" + ex);
    });
    Thread.sleep(10000);
}

```

Output: `ex` was null. And, `the exception` was included in `results`. It looks a bug.
```
results=[com.lambdaworks.redis.RedisCommandExecutionException: NOSCRIPT No matching script. Please use EVAL.]
ex=null
```