### PR TITLE
Fix srandmember return type from Set to List for Redis command specif…

### DIFF
--- a/src/main/java/com/lambdaworks/redis/AbstractRedisAsyncCommands.java
+++ b/src/main/java/com/lambdaworks/redis/AbstractRedisAsyncCommands.java
@@ -982,7 +982,7 @@ public abstract class AbstractRedisAsyncCommands<K, V>
     }
 
     @Override
-    public RedisFuture<Set<V>> srandmember(K key, long count) {
+    public RedisFuture<List<V>> srandmember(K key, long count) {
         return dispatch(commandBuilder.srandmember(key, count));
     }
 

--- a/src/main/java/com/lambdaworks/redis/RedisCommandBuilder.java
+++ b/src/main/java/com/lambdaworks/redis/RedisCommandBuilder.java
@@ -1262,11 +1262,11 @@ class RedisCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
         return createCommand(SRANDMEMBER, new ValueOutput<K, V>(codec), key);
     }
 
-    public Command<K, V, Set<V>> srandmember(K key, long count) {
+    public Command<K, V, List<V>> srandmember(K key, long count) {
         notNullKey(key);
 
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(count);
-        return createCommand(SRANDMEMBER, new ValueSetOutput<K, V>(codec), args);
+        return createCommand(SRANDMEMBER, new ValueListOutput<K, V>(codec), args);
     }
 
     public Command<K, V, Long> srandmember(ValueStreamingChannel<V> channel, K key, long count) {

--- a/src/main/java/com/lambdaworks/redis/RedisSetsAsyncConnection.java
+++ b/src/main/java/com/lambdaworks/redis/RedisSetsAsyncConnection.java
@@ -1,5 +1,6 @@
 package com.lambdaworks.redis;
 
+import java.util.List;
 import java.util.Set;
 
 import com.lambdaworks.redis.api.async.RedisSetAsyncCommands;
@@ -165,7 +166,7 @@ public interface RedisSetsAsyncConnection<K, V> {
      * @return RedisFuture&lt;Set&lt;V&gt;&gt; bulk-string-reply without the additional {@code count} argument the command
      *         returns a Bulk Reply with the randomly selected element, or {@literal null} when {@code key} does not exist.
      */
-    RedisFuture<Set<V>> srandmember(K key, long count);
+    RedisFuture<List<V>> srandmember(K key, long count);
 
     /**
      * Get one or multiple random members from a set.

--- a/src/main/java/com/lambdaworks/redis/RedisSetsConnection.java
+++ b/src/main/java/com/lambdaworks/redis/RedisSetsConnection.java
@@ -1,5 +1,6 @@
 package com.lambdaworks.redis;
 
+import java.util.List;
 import java.util.Set;
 
 import com.lambdaworks.redis.api.sync.RedisSetCommands;
@@ -165,7 +166,7 @@ public interface RedisSetsConnection<K, V> {
      * @return Set&lt;V&gt; bulk-string-reply without the additional {@code count} argument the command returns a Bulk Reply
      *         with the randomly selected element, or {@literal null} when {@code key} does not exist.
      */
-    Set<V> srandmember(K key, long count);
+    List<V> srandmember(K key, long count);
 
     /**
      * Get one or multiple random members from a set.

--- a/src/main/java/com/lambdaworks/redis/api/async/RedisSetAsyncCommands.java
+++ b/src/main/java/com/lambdaworks/redis/api/async/RedisSetAsyncCommands.java
@@ -1,5 +1,6 @@
 package com.lambdaworks.redis.api.async;
 
+import java.util.List;
 import java.util.Set;
 import com.lambdaworks.redis.ScanArgs;
 import com.lambdaworks.redis.ScanCursor;
@@ -167,7 +168,7 @@ public interface RedisSetAsyncCommands<K, V> {
      * @return Set&lt;V&gt; bulk-string-reply without the additional {@code count} argument the command returns a Bulk Reply
      *         with the randomly selected element, or {@literal null} when {@code key} does not exist.
      */
-    RedisFuture<Set<V>> srandmember(K key, long count);
+    RedisFuture<List<V>> srandmember(K key, long count);
 
     /**
      * Get one or multiple random members from a set.

--- a/src/main/java/com/lambdaworks/redis/api/sync/RedisSetCommands.java
+++ b/src/main/java/com/lambdaworks/redis/api/sync/RedisSetCommands.java
@@ -1,5 +1,6 @@
 package com.lambdaworks.redis.api.sync;
 
+import java.util.List;
 import java.util.Set;
 import com.lambdaworks.redis.ScanArgs;
 import com.lambdaworks.redis.ScanCursor;
@@ -166,7 +167,7 @@ public interface RedisSetCommands<K, V> {
      * @return Set&lt;V&gt; bulk-string-reply without the additional {@code count} argument the command returns a Bulk Reply
      *         with the randomly selected element, or {@literal null} when {@code key} does not exist.
      */
-    Set<V> srandmember(K key, long count);
+    List<V> srandmember(K key, long count);
 
     /**
      * Get one or multiple random members from a set.

--- a/src/main/java/com/lambdaworks/redis/cluster/api/async/NodeSelectionSetAsyncCommands.java
+++ b/src/main/java/com/lambdaworks/redis/cluster/api/async/NodeSelectionSetAsyncCommands.java
@@ -1,5 +1,6 @@
 package com.lambdaworks.redis.cluster.api.async;
 
+import java.util.List;
 import java.util.Set;
 import com.lambdaworks.redis.ScanArgs;
 import com.lambdaworks.redis.ScanCursor;
@@ -167,7 +168,7 @@ public interface NodeSelectionSetAsyncCommands<K, V> {
      * @return Set&lt;V&gt; bulk-string-reply without the additional {@code count} argument the command returns a Bulk Reply
      *         with the randomly selected element, or {@literal null} when {@code key} does not exist.
      */
-    AsyncExecutions<Set<V>> srandmember(K key, long count);
+    AsyncExecutions<List<V>> srandmember(K key, long count);
 
     /**
      * Get one or multiple random members from a set.

--- a/src/main/java/com/lambdaworks/redis/cluster/api/sync/NodeSelectionSetCommands.java
+++ b/src/main/java/com/lambdaworks/redis/cluster/api/sync/NodeSelectionSetCommands.java
@@ -1,5 +1,6 @@
 package com.lambdaworks.redis.cluster.api.sync;
 
+import java.util.List;
 import java.util.Set;
 import com.lambdaworks.redis.ScanArgs;
 import com.lambdaworks.redis.ScanCursor;
@@ -166,7 +167,7 @@ public interface NodeSelectionSetCommands<K, V> {
      * @return Set&lt;V&gt; bulk-string-reply without the additional {@code count} argument the command returns a Bulk Reply
      *         with the randomly selected element, or {@literal null} when {@code key} does not exist.
      */
-    Executions<Set<V>> srandmember(K key, long count);
+    Executions<List<V>> srandmember(K key, long count);
 
     /**
      * Get one or multiple random members from a set.

--- a/src/main/templates/com/lambdaworks/redis/api/RedisSetCommands.java
+++ b/src/main/templates/com/lambdaworks/redis/api/RedisSetCommands.java
@@ -166,7 +166,7 @@ public interface RedisSetCommands<K, V> {
      * @return Set&lt;V&gt; bulk-string-reply without the additional {@code count} argument the command returns a Bulk Reply
      *         with the randomly selected element, or {@literal null} when {@code key} does not exist.
      */
-    Set<V> srandmember(K key, long count);
+    List<V> srandmember(K key, long count);
 
     /**
      * Get one or multiple random members from a set.

--- a/src/test/java/com/lambdaworks/redis/commands/SetCommandTest.java
+++ b/src/test/java/com/lambdaworks/redis/commands/SetCommandTest.java
@@ -5,6 +5,7 @@ package com.lambdaworks.redis.commands;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -133,9 +134,11 @@ public class SetCommandTest extends AbstractRedisClientTest {
         redis.sadd(key, "a", "b", "c", "d");
         assertThat(set("a", "b", "c", "d").contains(redis.srandmember(key))).isTrue();
         assertThat(redis.smembers(key)).isEqualTo(set("a", "b", "c", "d"));
-        Set<String> rand = redis.srandmember(key, 3);
+        List<String> rand = redis.srandmember(key, 3);
         assertThat(rand).hasSize(3);
         assertThat(set("a", "b", "c", "d").containsAll(rand)).isTrue();
+        List<String> randWithDuplicates = redis.srandmember(key, -10);
+        assertThat(randWithDuplicates).hasSize(10);
     }
 
     @Test


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/mp911de/lettuce/blob/master/.github/CONTRIBUTING.md).
- [x] You use the code formatters provided [here](https://github.com/mp911de/lettuce/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
…ication

According to http://redis.io/commands/srandmember ,
if `count` is positive, results are distinct.
But, `count` is negative, it allows results contain same element multiple items.