### PR TITLE
Expose ByteBufAllocator in ClientResources

### DIFF
--- a/src/main/java/com/lambdaworks/redis/AbstractRedisClient.java
+++ b/src/main/java/com/lambdaworks/redis/AbstractRedisClient.java
@@ -47,7 +47,6 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  */
 public abstract class AbstractRedisClient {
 
-    protected static final PooledByteBufAllocator BUF_ALLOCATOR = PooledByteBufAllocator.DEFAULT;
     protected static final InternalLogger logger = InternalLoggerFactory.getInstance(RedisClient.class);
 
     /**
@@ -141,7 +140,7 @@ public abstract class AbstractRedisClient {
         Bootstrap redisBootstrap = new Bootstrap();
         redisBootstrap.option(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 32 * 1024);
         redisBootstrap.option(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, 8 * 1024);
-        redisBootstrap.option(ChannelOption.ALLOCATOR, BUF_ALLOCATOR);
+        redisBootstrap.option(ChannelOption.ALLOCATOR, clientResources.byteBufAllocator());
 
         SocketOptions socketOptions = getOptions().getSocketOptions();
 

--- a/src/main/java/com/lambdaworks/redis/resource/ClientResources.java
+++ b/src/main/java/com/lambdaworks/redis/resource/ClientResources.java
@@ -6,6 +6,7 @@ import com.lambdaworks.redis.event.EventBus;
 import com.lambdaworks.redis.event.EventPublisherOptions;
 import com.lambdaworks.redis.metrics.CommandLatencyCollector;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.Future;
 
@@ -121,4 +122,10 @@ public interface ClientResources {
      */
     Delay reconnectDelay();
 
+    /**
+     * Returns the {@link ByteBufAllocator} used for allocating memory.
+     *
+     * @return the byte buffer allocator.
+     */
+    ByteBufAllocator byteBufAllocator();
 }


### PR DESCRIPTION
To have more control over buffer allocation configuration, it would be
nice to include the option to choose what allocator to use.