### PR TITLE
Add jitter backoff strategies for spreading reconnection timing

### DIFF
--- a/src/main/java/com/lambdaworks/redis/resource/DecorrelatedJitterDelay.java
+++ b/src/main/java/com/lambdaworks/redis/resource/DecorrelatedJitterDelay.java
@@ -1,0 +1,44 @@
+package com.lambdaworks.redis.resource;
+
+import java.util.concurrent.TimeUnit;
+
+import com.lambdaworks.redis.resource.Delay.StatefulDelay;
+
+/**
+ * Delay that increases using decorrelated jitter strategy.
+ *
+ * <p>
+ * Considering retry attempts start at 1, attempt 0 would be the initial call and will always yield 0 (or the lower).
+ * Then, each retry step will by default yield <code>min(cap, randomBetween(base, prevDelay * 3))</code>.
+ *
+ * This strategy is based on <a href="https://www.awsarchitectureblog.com/2015/03/backoff.html">Exponential Backoff And Jitter</a>.
+ * </p>
+ */
+class DecorrelatedJitterDelay extends Delay implements StatefulDelay {
+
+    private final long lower;
+    private final long upper;
+    private final long base;
+    private long prevDelay;
+
+    DecorrelatedJitterDelay(long lower, long upper, long base, TimeUnit unit) {
+        super(unit);
+        this.lower = lower;
+        this.upper = upper;
+        this.base = base;
+        reset();
+    }
+
+    @Override
+    public long createDelay(long attempt) {
+        long value = randomBetween(base, Math.max(base, prevDelay * 3));
+        long delay = applyBounds(value, lower, upper);
+        prevDelay = delay;
+        return delay;
+    }
+
+    @Override
+    public void reset() {
+        prevDelay = 0L;
+    }
+}

--- a/src/main/java/com/lambdaworks/redis/resource/EqualJitterDelay.java
+++ b/src/main/java/com/lambdaworks/redis/resource/EqualJitterDelay.java
@@ -1,0 +1,29 @@
+package com.lambdaworks.redis.resource;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Delay that increases using equal jitter strategy.
+ *
+ * <p>
+ * Considering retry attempts start at 1, attempt 0 would be the initial call and will always yield 0 (or the lower).
+ * Then, each retry step will by default yield <code>randomBetween(0, base * 2 ^ (attempt - 1))</code>.
+ *
+ * This strategy is based on <a href="https://www.awsarchitectureblog.com/2015/03/backoff.html">Exponential Backoff And Jitter</a>.
+ * </p>
+ */
+class EqualJitterDelay extends ExponentialDelay {
+
+    private final long base;
+
+    EqualJitterDelay(long lower, long upper, long base, TimeUnit unit) {
+        super(lower, upper, unit, 2);
+        this.base = base;
+    }
+
+    @Override
+    public long createDelay(long attempt) {
+        long value = randomBetween(0, base * calculatePowerOfTwo(attempt));
+        return applyBounds(value, lower, upper);
+    }
+}

--- a/src/main/java/com/lambdaworks/redis/resource/FullJitterDelay.java
+++ b/src/main/java/com/lambdaworks/redis/resource/FullJitterDelay.java
@@ -1,0 +1,31 @@
+package com.lambdaworks.redis.resource;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Delay that increases using full jitter strategy.
+ *
+ * <p>
+ * Considering retry attempts start at 1, attempt 0 would be the initial call and will always yield 0 (or the lower).
+ * Then, each retry step will by default yield <code>temp / 2 + random_between(0, temp / 2)</code> and temp
+ * is <code>temp = min(upper, base * 2 ** attempt)</code>.
+ *
+ * This strategy is based on <a href="https://www.awsarchitectureblog.com/2015/03/backoff.html">Exponential Backoff And Jitter</a>.
+ * </p>
+ */
+class FullJitterDelay extends ExponentialDelay {
+
+    private final long base;
+
+    FullJitterDelay(long lower, long upper, long base, TimeUnit unit) {
+        super(lower, upper, unit, 2);
+        this.base = base;
+    }
+
+    @Override
+    public long createDelay(long attempt) {
+        long temp = Math.min(upper, base * calculatePowerOfTwo(attempt));
+        long delay = temp / 2 + randomBetween(0, temp / 2);
+        return applyBounds(delay, lower, upper);
+    }
+}

--- a/src/test/java/com/lambdaworks/redis/resource/DecorrelatedJitterDelayTest.java
+++ b/src/test/java/com/lambdaworks/redis/resource/DecorrelatedJitterDelayTest.java
@@ -1,0 +1,59 @@
+package com.lambdaworks.redis.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+public class DecorrelatedJitterDelayTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotCreateIfLowerBoundIsNegative() throws Exception {
+        Delay.decorrelatedJitter(-1, 100, 0, TimeUnit.MILLISECONDS);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotCreateIfLowerBoundIsSameAsUpperBound() throws Exception {
+        Delay.decorrelatedJitter(100, 100, 1, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void negativeAttemptShouldReturnZero() throws Exception {
+
+        Delay delay = Delay.decorrelatedJitter().get();
+
+        assertThat(delay.createDelay(-1)).isEqualTo(0);
+    }
+
+    @Test
+    public void zeroShouldReturnZero() throws Exception {
+
+        Delay delay = Delay.decorrelatedJitter().get();
+
+        assertThat(delay.createDelay(0)).isEqualTo(0);
+    }
+
+    @Test
+    public void testDefaultDelays() throws Exception {
+
+        Delay delay = Delay.decorrelatedJitter().get();
+
+        assertThat(delay.getTimeUnit()).isEqualTo(TimeUnit.MILLISECONDS);
+
+        for (int i = 0; i < 1000; i++) {
+            assertThat(delay.createDelay(1)).isBetween(0L, 1L);
+            assertThat(delay.createDelay(2)).isBetween(0L, 3L);
+            assertThat(delay.createDelay(3)).isBetween(0L, 9L);
+            assertThat(delay.createDelay(4)).isBetween(0L, 27L);
+            assertThat(delay.createDelay(5)).isBetween(0L, 81L);
+            assertThat(delay.createDelay(6)).isBetween(0L, 243L);
+            assertThat(delay.createDelay(7)).isBetween(0L, 729L);
+            assertThat(delay.createDelay(8)).isBetween(0L, 2187L);
+            assertThat(delay.createDelay(9)).isBetween(0L, 6561L);
+            assertThat(delay.createDelay(10)).isBetween(0L, 19683L);
+            assertThat(delay.createDelay(11)).isBetween(0L, 30000L);
+            assertThat(delay.createDelay(Integer.MAX_VALUE)).isBetween(0L, 30000L);
+        }
+    }
+}

--- a/src/test/java/com/lambdaworks/redis/resource/EqualJitterDelayTest.java
+++ b/src/test/java/com/lambdaworks/redis/resource/EqualJitterDelayTest.java
@@ -1,0 +1,63 @@
+package com.lambdaworks.redis.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+public class EqualJitterDelayTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotCreateIfLowerBoundIsNegative() throws Exception {
+        Delay.equalJitter(-1, 100, 1, TimeUnit.MILLISECONDS);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotCreateIfLowerBoundIsSameAsUpperBound() throws Exception {
+        Delay.equalJitter(100, 100, 1, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void negativeAttemptShouldReturnZero() throws Exception {
+
+        Delay delay = Delay.equalJitter();
+
+        assertThat(delay.createDelay(-1)).isEqualTo(0);
+    }
+
+    @Test
+    public void zeroShouldReturnZero() throws Exception {
+
+        Delay delay = Delay.equalJitter();
+
+        assertThat(delay.createDelay(0)).isEqualTo(0);
+    }
+
+    @Test
+    public void testDefaultDelays() throws Exception {
+
+        Delay delay = Delay.equalJitter();
+
+        assertThat(delay.getTimeUnit()).isEqualTo(TimeUnit.MILLISECONDS);
+
+        assertThat(delay.createDelay(1)).isBetween(0L, 1L);
+        assertThat(delay.createDelay(2)).isBetween(0L, 2L);
+        assertThat(delay.createDelay(3)).isBetween(0L, 4L);
+        assertThat(delay.createDelay(4)).isBetween(0L, 8L);
+        assertThat(delay.createDelay(5)).isBetween(0L, 16L);
+        assertThat(delay.createDelay(6)).isBetween(0L, 32L);
+        assertThat(delay.createDelay(7)).isBetween(0L, 64L);
+        assertThat(delay.createDelay(8)).isBetween(0L, 128L);
+        assertThat(delay.createDelay(9)).isBetween(0L, 256L);
+        assertThat(delay.createDelay(10)).isBetween(0L, 512L);
+        assertThat(delay.createDelay(11)).isBetween(0L, 1024L);
+        assertThat(delay.createDelay(12)).isBetween(0L, 2048L);
+        assertThat(delay.createDelay(13)).isBetween(0L, 4096L);
+        assertThat(delay.createDelay(14)).isBetween(0L, 8192L);
+        assertThat(delay.createDelay(15)).isBetween(0L, 16384L);
+        assertThat(delay.createDelay(16)).isBetween(0L, 30000L);
+        assertThat(delay.createDelay(17)).isBetween(0L, 30000L);
+        assertThat(delay.createDelay(Integer.MAX_VALUE)).isBetween(0L, 30000L);
+    }
+}

--- a/src/test/java/com/lambdaworks/redis/resource/FullJitterDelayTest.java
+++ b/src/test/java/com/lambdaworks/redis/resource/FullJitterDelayTest.java
@@ -1,0 +1,63 @@
+package com.lambdaworks.redis.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+public class FullJitterDelayTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotCreateIfLowerBoundIsNegative() throws Exception {
+        Delay.fullJitter(-1, 100, 1, TimeUnit.MILLISECONDS);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotCreateIfLowerBoundIsSameAsUpperBound() throws Exception {
+        Delay.fullJitter(100, 100, 1, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void negativeAttemptShouldReturnZero() throws Exception {
+
+        Delay delay = Delay.fullJitter();
+
+        assertThat(delay.createDelay(-1)).isEqualTo(0);
+    }
+
+    @Test
+    public void zeroShouldReturnZero() throws Exception {
+
+        Delay delay = Delay.fullJitter();
+
+        assertThat(delay.createDelay(0)).isEqualTo(0);
+    }
+
+    @Test
+    public void testDefaultDelays() throws Exception {
+
+        Delay delay = Delay.fullJitter();
+
+        assertThat(delay.getTimeUnit()).isEqualTo(TimeUnit.MILLISECONDS);
+
+        assertThat(delay.createDelay(1)).isBetween(0L, 1L);
+        assertThat(delay.createDelay(2)).isBetween(1L, 2L);
+        assertThat(delay.createDelay(3)).isBetween(2L, 4L);
+        assertThat(delay.createDelay(4)).isBetween(4L, 8L);
+        assertThat(delay.createDelay(5)).isBetween(8L, 16L);
+        assertThat(delay.createDelay(6)).isBetween(16L, 32L);
+        assertThat(delay.createDelay(7)).isBetween(32L, 64L);
+        assertThat(delay.createDelay(8)).isBetween(64L, 128L);
+        assertThat(delay.createDelay(9)).isBetween(128L, 256L);
+        assertThat(delay.createDelay(10)).isBetween(256L, 512L);
+        assertThat(delay.createDelay(11)).isBetween(512L, 1024L);
+        assertThat(delay.createDelay(12)).isBetween(1024L, 2048L);
+        assertThat(delay.createDelay(13)).isBetween(2048L, 4096L);
+        assertThat(delay.createDelay(14)).isBetween(4096L, 8192L);
+        assertThat(delay.createDelay(15)).isBetween(8192L, 16384L);
+        assertThat(delay.createDelay(16)).isBetween(15000L, 30000L);
+        assertThat(delay.createDelay(17)).isBetween(15000L, 30000L);
+        assertThat(delay.createDelay(Integer.MAX_VALUE)).isBetween(15000L, 30000L);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/mp911de/lettuce/blob/master/.github/CONTRIBUTING.md).
- [x] You use the code formatters provided [here](https://github.com/mp911de/lettuce/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

When users use exponential backoff streategy and connection pool with more than thousands of application servers, sometimes connection bursting is occured in Redis instance.
Because it's reconnection timings are all same when Redis server is under slowlog or network problem.
This patch will fix the problem using well known jitter backoff strategies.

Equal Jitter

    sleep = random_between(0, min(cap, base * 2 ** attempt))

Full Jitter

    temp = min(cap, base * 2 ** attempt)
    sleep = temp / 2 + random_between(0, temp / 2)

Decorrelated Jitter

    sleep = min(cap, random_between(base, sleep * 3))

Rerenrence: https://www.awsarchitectureblog.com/2015/03/backoff.html