### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ Basic Usage
 
 ```java
 RedisClient client = RedisClient.create("redis://localhost");
-RedisStringsConnection<String, String> connection = client.connect();
-String value = connection.get("key");
+StatefulRedisConnection<String, String> connection = client.connect();
+RedisStringCommands sync = connection.sync();
+String value = sync.get("key");
 ```
 
 Each Redis command is implemented by one or more methods with names identical


### PR DESCRIPTION
README.md is as follows.

```Java
RedisClient client = RedisClient.create ( "redis: // localhost");
RedisStringsConnection <String, String> connection = client.connect ();
String value = connection.get ( "key");
```

But, http://www.paluch.biz/blog/153-redis-client-lettuce-3-3-1-and-4-0-final-released.html is as follows.

```
By calling connect() you will be no longer get a synchronous connection, you will get StatefulRedisConnection with the access to the synchronous, asynchronous and reactive API.
```

So, I change it to the following.

```java
RedisClient client = RedisClient.create("redis://localhost");
StatefulRedisConnection<String, String> connection = client.connect();
RedisStringCommands sync = connection.sync();
String value = sync.get("key");
```

close #409 