### PR TITLE
Explicit exception when non-multi command is called during a multi block

### DIFF
--- a/src/main/java/com/lambdaworks/redis/FutureSyncInvocationHandler.java
+++ b/src/main/java/com/lambdaworks/redis/FutureSyncInvocationHandler.java
@@ -56,7 +56,7 @@ class FutureSyncInvocationHandler<K, V> extends AbstractInvocationHandler {
                 RedisFuture<?> command = (RedisFuture<?>) result;
                 if (!method.getName().equals("exec") && !method.getName().equals("multi")) {
                     if (connection instanceof StatefulRedisConnection && ((StatefulRedisConnection) connection).isMulti()) {
-                        return null;
+                        throw new IllegalStateException("Unable to execute non-MULTI command during MULTI block.  Be sure your connection is not being shared between multiple threads during a MULTI block.");
                     }
                 }
 


### PR DESCRIPTION
Tracking down the series of bugs was arduous for this case as the levels of indirection when making a call start to stack up.  My initial comment is about the placement and form of this check, as it isn't explicit in any contracts that call into it, but I'll settle for a fail-fast method with a clear message!