### PR TITLE
improve RedisStateMachine's constructor

### DIFF
--- a/src/main/java/com/lambdaworks/redis/protocol/RedisStateMachine.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/RedisStateMachine.java
@@ -46,6 +46,25 @@ public class RedisStateMachine<K, V> {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(RedisStateMachine.class);
     private static final ByteBuffer QUEUED = buffer("QUEUED");
 
+    private static final boolean USE_NETTY40_BYTEBUF_COMPATIBILITY;
+    private static final Class LONG_PROCESSOR_CLASS;
+
+    static {
+        Version nettyBufferVersion = Version.identify().get("netty-buffer");
+
+        USE_NETTY40_BYTEBUF_COMPATIBILITY =
+                nettyBufferVersion != null && nettyBufferVersion.artifactVersion().startsWith("4.0");
+        if (!USE_NETTY40_BYTEBUF_COMPATIBILITY) {
+            try {
+                LONG_PROCESSOR_CLASS = Class.forName("com.lambdaworks.redis.protocol.RedisStateMachine$Netty41LongProcessor");
+            } catch (ClassNotFoundException e) {
+                throw new RedisException("Cannot create Netty41ToLongProcessor instance", e);
+            }
+        } else {
+            LONG_PROCESSOR_CLASS = null;
+        }
+    }
+
     static class State {
         enum Type {
             SINGLE, ERROR, INTEGER, BULK, MULTI, BYTES
@@ -68,18 +87,10 @@ public class RedisStateMachine<K, V> {
      */
     public RedisStateMachine() {
 
-        Version nettyBufferVersion = Version.identify().get("netty-buffer");
-
-        boolean useNetty40ByteBufCompatibility = false;
-        if (nettyBufferVersion != null) {
-            useNetty40ByteBufCompatibility = nettyBufferVersion.artifactVersion().startsWith("4.0");
-        }
-
         LongProcessor longProcessor;
-        if (!useNetty40ByteBufCompatibility) {
+        if (!USE_NETTY40_BYTEBUF_COMPATIBILITY) {
             try {
-                longProcessor = (LongProcessor) Class
-                        .forName("com.lambdaworks.redis.protocol.RedisStateMachine$Netty41LongProcessor").newInstance();
+                longProcessor = (LongProcessor) LONG_PROCESSOR_CLASS.newInstance();
             } catch (ReflectiveOperationException e) {
                 throw new RedisException("Cannot create Netty41ToLongProcessor instance", e);
             }

--- a/src/test/java/com/lambdaworks/redis/protocol/AbstractRedisStateMachineTest.java
+++ b/src/test/java/com/lambdaworks/redis/protocol/AbstractRedisStateMachineTest.java
@@ -1,0 +1,53 @@
+package com.lambdaworks.redis.protocol;
+
+import com.lambdaworks.redis.RedisException;
+import io.netty.util.Version;
+import org.junit.Test;
+
+import static com.lambdaworks.redis.protocol.RedisStateMachine.LongProcessor;
+
+public abstract class AbstractRedisStateMachineTest {
+
+    private boolean useNetty40ByteBufCompatibility;
+    private Class longProcessorClass;
+
+    @Test
+    public void test() {
+        long start = System.currentTimeMillis();
+        newInstanceTest();
+        long end = System.currentTimeMillis();
+        System.out.println("cost time:" + (end - start) + "ms");
+    }
+
+    protected abstract void newInstanceTest();
+
+    protected void init() {
+        Version nettyBufferVersion = Version.identify().get("netty-buffer");
+
+        useNetty40ByteBufCompatibility = nettyBufferVersion != null && nettyBufferVersion.artifactVersion().startsWith("4.0");
+        if (!useNetty40ByteBufCompatibility) {
+            try {
+                longProcessorClass = Class.forName("com.lambdaworks.redis.protocol.RedisStateMachine$Netty41LongProcessor");
+            } catch (ClassNotFoundException e) {
+                throw new RedisException("Cannot create Netty41ToLongProcessor instance", e);
+            }
+        } else {
+            longProcessorClass = null;
+        }
+    }
+
+    protected LongProcessor newInstance() {
+        LongProcessor longProcessor;
+        if (!useNetty40ByteBufCompatibility) {
+            try {
+                longProcessor = (LongProcessor) longProcessorClass.newInstance();
+            } catch (ReflectiveOperationException e) {
+                throw new RedisException("Cannot create Netty41ToLongProcessor instance", e);
+            }
+        } else {
+            longProcessor = new LongProcessor();
+        }
+        return longProcessor;
+    }
+
+}

--- a/src/test/java/com/lambdaworks/redis/protocol/RedisStateMachineOldTest.java
+++ b/src/test/java/com/lambdaworks/redis/protocol/RedisStateMachineOldTest.java
@@ -1,0 +1,12 @@
+package com.lambdaworks.redis.protocol;
+
+public class RedisStateMachineOldTest extends AbstractRedisStateMachineTest {
+
+    protected void newInstanceTest() {
+        for (int i = 0; i < 10000; i++) {
+            init();
+            newInstance();
+        }
+    }
+
+}

--- a/src/test/java/com/lambdaworks/redis/protocol/RedisStateMachineTest.java
+++ b/src/test/java/com/lambdaworks/redis/protocol/RedisStateMachineTest.java
@@ -1,0 +1,12 @@
+package com.lambdaworks.redis.protocol;
+
+public class RedisStateMachineTest extends AbstractRedisStateMachineTest {
+
+    protected void newInstanceTest() {
+        init();
+        for (int i = 0; i < 10000; i++) {
+            newInstance();
+        }
+    }
+
+}


### PR DESCRIPTION
Running com.lambdaworks.redis.protocol.RedisStateMachineOldTest
cost time:14657ms
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.79 sec - in com.lambdaworks.redis.protocol.RedisStateMachineOldTest
Running com.lambdaworks.redis.protocol.RedisStateMachineTest
cost time:6ms
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 sec - in com.lambdaworks.redis.protocol.RedisStateMachineTest