### PR TITLE
Add shutdownAsync for RedisClient

### DIFF
--- a/src/main/java/com/lambdaworks/redis/AbstractRedisClient.java
+++ b/src/main/java/com/lambdaworks/redis/AbstractRedisClient.java
@@ -18,6 +18,7 @@ package com.lambdaworks.redis;
 import java.io.Closeable;
 import java.net.SocketAddress;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -354,6 +355,32 @@ public abstract class AbstractRedisClient {
      * @param timeUnit the unit of {@code quietPeriod} and {@code timeout}
      */
     public void shutdown(long quietPeriod, long timeout, TimeUnit timeUnit) {
+        try {
+            final CompletableFuture<Void> future = shutdownAsync(quietPeriod, timeout, timeUnit);
+            future.get();
+        } catch (Exception e) {
+            throw new RedisException(e);
+        }
+    }
+
+    /**
+     * Shutdown this client and close all open connections asynchronously. The client should be discarded
+     * after calling shutdown. The shutdown has 2 secs quiet time and a timeout of 15 secs.
+     */
+    public CompletableFuture<Void> shutdownAsync() {
+        return shutdownAsync(2, 15, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Shutdown this client and close all open connections asynchronously. The client should be discarded
+     * after calling shutdown.
+     *
+     * @param quietPeriod the quiet period as described in the documentation
+     * @param timeout the maximum amount of time to wait until the executor is shutdown regardless if a task was submitted
+     *        during the quiet period
+     * @param timeUnit the unit of {@code quietPeriod} and {@code timeout}
+     */
+    public CompletableFuture<Void> shutdownAsync(long quietPeriod, long timeout, TimeUnit timeUnit) {
 
         if (shutdown.compareAndSet(false, true)) {
 
@@ -367,7 +394,7 @@ public abstract class AbstractRedisClient {
                 closeableResources.remove(closeableResource);
             }
 
-            List<Future<?>> closeFutures = new ArrayList<>();
+            List<CompletableFuture<Void>> closeFutures = new ArrayList<>();
 
             for (Channel c : channels) {
                 ChannelPipeline pipeline = c.pipeline();
@@ -384,29 +411,25 @@ public abstract class AbstractRedisClient {
             }
 
             try {
-                closeFutures.add(channels.close());
+                closeFutures.add(toCompletableFuture(channels.close()));
             } catch (Exception e) {
                 logger.debug("Cannot close channels", e);
             }
 
             if (!sharedResources) {
                 Future<?> groupCloseFuture = clientResources.shutdown(quietPeriod, timeout, timeUnit);
-                closeFutures.add(groupCloseFuture);
+                closeFutures.add(toCompletableFuture(groupCloseFuture));
             } else {
                 for (EventLoopGroup eventExecutors : eventLoopGroups.values()) {
                     Future<?> groupCloseFuture = clientResources.eventLoopGroupProvider().release(eventExecutors, quietPeriod,
                             timeout, timeUnit);
-                    closeFutures.add(groupCloseFuture);
+                    closeFutures.add(toCompletableFuture(groupCloseFuture));
                 }
             }
 
-            for (Future<?> future : closeFutures) {
-                try {
-                    future.get();
-                } catch (Exception e) {
-                    throw new RedisException(e);
-                }
-            }
+            return CompletableFuture.allOf(toArray(closeFutures));
+        } else {
+            return CompletableFuture.completedFuture(null);
         }
     }
 
@@ -460,5 +483,22 @@ public abstract class AbstractRedisClient {
     protected void setOptions(ClientOptions clientOptions) {
         LettuceAssert.notNull(clientOptions, "ClientOptions must not be null");
         this.clientOptions = clientOptions;
+    }
+
+    private static CompletableFuture<Void> toCompletableFuture(Future<?> future) {
+        final CompletableFuture<Void> promise = new CompletableFuture<>();
+        future.addListener(f -> {
+            if (f.isSuccess()) {
+                promise.complete(null);
+            } else {
+                promise.completeExceptionally(f.cause());
+            }
+        });
+        return promise;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <T> CompletableFuture<T>[] toArray(Collection<CompletableFuture<T>> collection) {
+        return collection.stream().toArray(CompletableFuture[]::new);
     }
 }

--- a/src/test/java/com/lambdaworks/redis/RedisClientConnectionTest.java
+++ b/src/test/java/com/lambdaworks/redis/RedisClientConnectionTest.java
@@ -18,7 +18,9 @@ package com.lambdaworks.redis;
 import static com.lambdaworks.redis.RedisURI.Builder.redis;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -132,6 +134,37 @@ public class RedisClientConnectionTest extends AbstractRedisClientTest {
     @Test(expected = IllegalArgumentException.class)
     public void connectcodecSentinelMissingHostAndSocketUri() throws Exception {
         client.connect(CODEC, invalidSentinel());
+    }
+
+    /*
+     * Client shutdown sync/async test.
+     */
+    @Test(expected = TimeoutException.class)
+    public void shutdownSyncInRedisFutureTest() throws Exception {
+        RedisClient redisClient = RedisClient.create();
+        StatefulRedisConnection<String, String> connection = redisClient.connect(redis(host, port).build());
+        CompletableFuture<String> f = connection.async()
+                                                .get("key1")
+                                                .whenComplete((result, e) -> {
+                                                    connection.close();
+                                                    redisClient.shutdown(); // deadlock.
+                                                })
+                                                .toCompletableFuture();
+        f.get(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void shutdownAsyncInRedisFutureTest() throws Exception {
+        RedisClient redisClient = RedisClient.create();
+        StatefulRedisConnection<String, String> connection = redisClient.connect(redis(host, port).build());
+        CompletableFuture<Void> f = connection.async()
+                                              .get("key1")
+                                              .thenCompose(result -> {
+                                                  connection.close();
+                                                  return redisClient.shutdownAsync();
+                                              })
+                                              .toCompletableFuture();
+        f.get(5, TimeUnit.SECONDS);
     }
 
     /*


### PR DESCRIPTION
Currently, if users call `shutdown()` in RedisFuture handler, it'll be a deadlock.
To solve this, introduced `shutdownAsync()` for RedisClient.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/mp911de/lettuce/blob/master/.github/CONTRIBUTING.md).
- [x] You use the code formatters provided [here](https://github.com/mp911de/lettuce/blob/master/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->